### PR TITLE
Workload identity support for cosmosDB external scaler 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The specification below describes the `trigger` metadata in `ScaledObject` resou
       metadata:
         scalerAddress: external-scaler-azure-cosmos-db.keda:4050    # Mandatory. Address of the external scaler service.
 
-        # Database & Container proeprties
+        # Database & Container properties
         databaseId: <database-id>                                   # Mandatory. ID of Cosmos DB database containing monitored container.
         containerId: <container-id>                                 # Mandatory. ID of monitored container.
         leaseDatabaseId: <lease-database-id>                        # Mandatory. ID of Cosmos DB database containing lease container.
@@ -79,10 +79,10 @@ The specification below describes the `trigger` metadata in `ScaledObject` resou
         connectionFromEnv: <env-variable-for-connection>            # Optional. Environment variable for the connection string of Cosmos DB account with monitored container.
         leaseConnectionFromEnv: <env-variable-for-lease-connection> # Optional. Environment variable for the connection string of Cosmos DB account with lease container.
 
-        # Managed Identity properties
+        # Managed Identity properties.
         endpoint: <endpoint>                                        # Optional. Account endpoint of the CosmosDB account containing the monitored container.
         leaseEndpoint: <lease-endpoint>                             # Optional. Account endpoint of the CosmosDB account containing the lease container.
-        clientId: <client-Id>                                       # Optional. ClientId of the identity to be used. System assigned identity is used, if this is null.
+        clientId: <client-Id>                                       # Optional. Client ID of the identity to be used. System assigned identity is used, if this is not provided.
 
         processorName: <processor-name>                             # Mandatory. Name of change-feed processor used by listener application.
 ```
@@ -90,7 +90,7 @@ The specification below describes the `trigger` metadata in `ScaledObject` resou
 ### Parameter List
 
 - **`scalerAddress`** - Address of the external scaler service. This would be in format `<scaler-name>.<scaler-namespace>:<port>`. If you installed Azure Cosmos DB external scaler Helm chart in `keda` namespace and did not specify custom values, the metadata value would be `external-scaler-azure-cosmos-db.keda:4050`.
-- **Database & Container properties:**
+- **Database & Container Properties:**
   - **`databaseId`** - ID of Cosmos DB database that contains the monitored container.
   - **`containerId`** - ID of the monitored container.
   - **`leaseDatabaseId`** - ID of Cosmos DB database that contains the lease container. This can be same or different from the value of `databaseId` metadata.

--- a/deploy/deploy-scaledobject-cs.yaml
+++ b/deploy/deploy-scaledobject-cs.yaml
@@ -1,0 +1,22 @@
+# Template scaled-object for using KEDA external scaler for Azure Cosmos DB, using connection strings.
+
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: <scaledobject-name>
+  namespace: default
+spec:
+  pollingInterval: 20
+  scaleTargetRef:
+    name: <application-deployment-name>
+  triggers:
+    - type: external
+      metadata:
+        scalerAddress: external-scaler-azure-cosmos-db.keda:4050
+        databaseId: <database-id>
+        containerId: <container-id>
+        leaseDatabaseId: <lease-database-id>
+        leaseContainerId: <lease-container-id>
+        connectionFromEnv: <env-variable-for-connection-string-of-monitored-container-account>
+        leaseConnectionFromEnv: <env-variable-for-connection-string-of-lease-container-account>
+        processorName: <processor-name>

--- a/deploy/deploy-scaledobject-mi.yaml
+++ b/deploy/deploy-scaledobject-mi.yaml
@@ -1,4 +1,4 @@
-# Template scaled-object for using KEDA external scaler for Azure Cosmos DB, using connection strings.
+# Template scaled-object for using KEDA external scaler for Azure Cosmos DB, using managed identity.
 
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -18,6 +18,6 @@ spec:
         leaseDatabaseId: <lease-database-id>
         leaseContainerId: <lease-container-id>
         endpoint: <endpoint>
-        leaseEndpoint: <leaseEndpoint>
-        clientId: <clientId>
+        leaseEndpoint: <lease-endpoint>
+        clientId: <client-id>
         processorName: <processor-name>

--- a/deploy/deploy-scaledobject-mi.yaml
+++ b/deploy/deploy-scaledobject-mi.yaml
@@ -1,4 +1,4 @@
-# Template scaled-object for using KEDA external scaler for Azure Cosmos DB.
+# Template scaled-object for using KEDA external scaler for Azure Cosmos DB, using connection strings.
 
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -13,10 +13,11 @@ spec:
     - type: external
       metadata:
         scalerAddress: external-scaler-azure-cosmos-db.keda:4050
-        connectionFromEnv: <env-variable-for-connection-string-of-monitored-container-account>
         databaseId: <database-id>
         containerId: <container-id>
-        leaseConnectionFromEnv: <env-variable-for-connection-string-of-lease-container-account>
         leaseDatabaseId: <lease-database-id>
         leaseContainerId: <lease-container-id>
+        endpoint: <endpoint>
+        leaseEndpoint: <leaseEndpoint>
+        clientId: <clientId>
         processorName: <processor-name>

--- a/deploy/service-account-mi.yaml
+++ b/deploy/service-account-mi.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <service-account-name>  
+  annotations:
+    azure.workload.identity/client-id: <>
+    azure.workload.identity/tenant-id: <>

--- a/deploy/service-account-mi.yaml
+++ b/deploy/service-account-mi.yaml
@@ -3,5 +3,5 @@ kind: ServiceAccount
 metadata:
   name: <service-account-name>  
   annotations:
-    azure.workload.identity/client-id: <>
-    azure.workload.identity/tenant-id: <>
+    azure.workload.identity/client-id: <client-id>
+    azure.workload.identity/tenant-id: <tenant-id>

--- a/src/Scaler.Demo/OrderGenerator/Program.cs
+++ b/src/Scaler.Demo/OrderGenerator/Program.cs
@@ -44,8 +44,8 @@ namespace Keda.CosmosDb.Scaler.Demo.OrderGenerator
         {
             Container container = DemoHelper.CreateCosmosClient(
                     _cosmosDbConfig.Connection, 
-                    !string.IsNullOrWhiteSpace(_cosmosDbConfig.MSIClientID), 
-                    _cosmosDbConfig.MSIClientID, _applicationName)
+                    !string.IsNullOrWhiteSpace(_cosmosDbConfig.MsiClientId), 
+                    _cosmosDbConfig.MsiClientId, _applicationName)
                 .GetDatabase(_cosmosDbConfig.DatabaseId)
                 .GetContainer(_cosmosDbConfig.ContainerId);
 
@@ -92,8 +92,8 @@ namespace Keda.CosmosDb.Scaler.Demo.OrderGenerator
 
             Database database = await DemoHelper.CreateCosmosClient(
                     _cosmosDbConfig.Connection,
-                    !string.IsNullOrWhiteSpace(_cosmosDbConfig.MSIClientID),
-                    _cosmosDbConfig.MSIClientID, _applicationName)
+                    !string.IsNullOrWhiteSpace(_cosmosDbConfig.MsiClientId),
+                    _cosmosDbConfig.MsiClientId, _applicationName)
                 .CreateDatabaseIfNotExistsAsync(_cosmosDbConfig.DatabaseId);
 
             Console.WriteLine($"Creating container: {_cosmosDbConfig.ContainerId} with throughput: {_cosmosDbConfig.ContainerThroughput} RU/s");

--- a/src/Scaler.Demo/OrderGenerator/Program.cs
+++ b/src/Scaler.Demo/OrderGenerator/Program.cs
@@ -23,9 +23,21 @@ namespace Keda.CosmosDb.Scaler.Demo.OrderGenerator
                 .ConfigureAppConfiguration(builder => _cosmosDbConfig = CosmosDbConfig.Create(builder.Build()))
                 .Build();
 
-            await SetupAsync();
-            await CreateOrdersAsync(_cosmosDbConfig.OrderCount, _cosmosDbConfig.IsSingleArticle);
-            await TeardownAsync();
+            switch (_cosmosDbConfig.Action)
+            {
+                case "setup":
+                    await SetupAsync();
+                    break;
+                case "teardown":
+                    await TeardownAsync();
+                    break;
+                case "generate":
+                    await CreateOrdersAsync(_cosmosDbConfig.OrderCount, _cosmosDbConfig.IsSingleArticle);
+                    break;
+                default:
+                    Console.WriteLine("Invalid action. Valid actions are: setup, teardown, generate");
+                    break;
+            }
         }
 
         private static async Task CreateOrdersAsync(int count, bool isSingleArticle)

--- a/src/Scaler.Demo/OrderGenerator/deploy.yaml
+++ b/src/Scaler.Demo/OrderGenerator/deploy.yaml
@@ -3,22 +3,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cosmosdb-order-processor
+  name: cosmosdb-order-generator
   namespace: default
 spec:
   replicas: 1 # A replica is required to be up momentarily to initialize the change-feed.
   selector:
     matchLabels:
-      app: cosmosdb-order-processor
+      app: cosmosdb-order-generator
   template:
     metadata:
       labels:
-        app: cosmosdb-order-processor
+        app: cosmosdb-order-generator
         azure.workload.identity/use: "true"
     spec:
       serviceAccountName: sa
       containers:
-        - name: cosmosdb-order-processor
+        - name: cosmosdb-order-generator
           image: <>
           imagePullPolicy: Always
           env:
@@ -38,3 +38,7 @@ spec:
               value: "OrderProcessorLeases"
             - name: CosmosDbConfig__ProcessorName
               value: "OrderProcessor"
+            - name: CosmosDbConfig__OrderCount
+              value: "1000"
+            - name: CosmosDbConfig__IsSingleArticle
+              value: "false"

--- a/src/Scaler.Demo/OrderGenerator/deploy.yaml
+++ b/src/Scaler.Demo/OrderGenerator/deploy.yaml
@@ -16,18 +16,18 @@ spec:
         app: cosmosdb-order-generator
         azure.workload.identity/use: "true"
     spec:
-      serviceAccountName: sa
+      serviceAccountName: <service-account-name>
       containers:
         - name: cosmosdb-order-generator
-          image: <>
+          image: <image-name>
           imagePullPolicy: Always
           env:
             - name: CosmosDbConfig__Connection
-              value: "<>"
+              value: "<endpoint or connection-string>"
             - name: CosmosDbConfig__LeaseConnection
-              value: "<>"
-            - name: CosmosDbConfig__MSIClientId
-              value: "<>"
+              value: "<endpoint or connection-string>"
+            - name: CosmosDbConfig__MsiClientId
+              value: "<client-id>"
             - name: CosmosDbConfig__DatabaseId
               value: "StoreDatabase"
             - name: CosmosDbConfig__ContainerId

--- a/src/Scaler.Demo/OrderGenerator/deploy.yaml
+++ b/src/Scaler.Demo/OrderGenerator/deploy.yaml
@@ -42,3 +42,5 @@ spec:
               value: "1000"
             - name: CosmosDbConfig__IsSingleArticle
               value: "false"
+            - name: CosmosDbConfig__Action
+              value: "setup" #options: setup, teardown, generate

--- a/src/Scaler.Demo/OrderProcessor/Worker.cs
+++ b/src/Scaler.Demo/OrderProcessor/Worker.cs
@@ -29,8 +29,8 @@ namespace Keda.CosmosDb.Scaler.Demo.OrderProcessor
         {
             Database leaseDatabase = await DemoHelper.CreateCosmosClient(
                     _cosmosDbConfig.Connection,
-                    !string.IsNullOrWhiteSpace(_cosmosDbConfig.MSIClientID),
-                    _cosmosDbConfig.MSIClientID, _applicationName)
+                    !string.IsNullOrWhiteSpace(_cosmosDbConfig.MsiClientId),
+                    _cosmosDbConfig.MsiClientId, _applicationName)
                 .CreateDatabaseIfNotExistsAsync(_cosmosDbConfig.LeaseDatabaseId, cancellationToken: cancellationToken);
 
             Container leaseContainer = await leaseDatabase
@@ -43,8 +43,8 @@ namespace Keda.CosmosDb.Scaler.Demo.OrderProcessor
 
             _processor = DemoHelper.CreateCosmosClient(
                     _cosmosDbConfig.Connection,
-                    !string.IsNullOrWhiteSpace(_cosmosDbConfig.MSIClientID),
-                    _cosmosDbConfig.MSIClientID, _applicationName)
+                    !string.IsNullOrWhiteSpace(_cosmosDbConfig.MsiClientId),
+                    _cosmosDbConfig.MsiClientId, _applicationName)
                 .GetContainer(_cosmosDbConfig.DatabaseId, _cosmosDbConfig.ContainerId)
                 .GetChangeFeedProcessorBuilder<Order>(_cosmosDbConfig.ProcessorName, ProcessOrdersAsync)
                 .WithInstanceName(instanceName)

--- a/src/Scaler.Demo/OrderProcessor/deploy-scaledobject.yaml
+++ b/src/Scaler.Demo/OrderProcessor/deploy-scaledobject.yaml
@@ -22,6 +22,6 @@ spec:
         leaseDatabaseId: StoreDatabase
         leaseContainerId: OrderProcessorLeases
         processorName: OrderProcessor
-        endpoint: "<>"
-        leaseEndpoint: "<>"
-        clientId: "145385f0-1987-4ffa-a9c5-a84731220641"
+        endpoint: "<cosmosdb-endpoint>"
+        leaseEndpoint: "<cosmosdb-endpoint>"
+        clientId: "<client-id>"

--- a/src/Scaler.Demo/OrderProcessor/deploy-scaledobject.yaml
+++ b/src/Scaler.Demo/OrderProcessor/deploy-scaledobject.yaml
@@ -15,10 +15,11 @@ spec:
     - type: external
       metadata:
         scalerAddress: cosmosdb-scaler.default:4050
-        connectionFromEnv: CosmosDbConfig__Connection
         databaseId: StoreDatabase
         containerId: OrderContainer
-        leaseConnectionFromEnv: CosmosDbConfig__LeaseConnection
         leaseDatabaseId: StoreDatabase
         leaseContainerId: OrderProcessorLeases
         processorName: OrderProcessor
+        endpoint: "<>"
+        leaseEndpoint: "<>"
+        clientId: "145385f0-1987-4ffa-a9c5-a84731220641"

--- a/src/Scaler.Demo/OrderProcessor/deploy-scaledobject.yaml
+++ b/src/Scaler.Demo/OrderProcessor/deploy-scaledobject.yaml
@@ -15,8 +15,10 @@ spec:
     - type: external
       metadata:
         scalerAddress: cosmosdb-scaler.default:4050
+        connectionFromEnv: CosmosDbConfig__Connection
         databaseId: StoreDatabase
         containerId: OrderContainer
+        leaseConnectionFromEnv: CosmosDbConfig__LeaseConnection
         leaseDatabaseId: StoreDatabase
         leaseContainerId: OrderProcessorLeases
         processorName: OrderProcessor

--- a/src/Scaler.Demo/OrderProcessor/deploy.yaml
+++ b/src/Scaler.Demo/OrderProcessor/deploy.yaml
@@ -16,7 +16,7 @@ spec:
         app: cosmosdb-order-processor
         azure.workload.identity/use: "true"
     spec:
-      serviceAccountName: sa
+      serviceAccountName: <service-account-name>
       containers:
         - name: cosmosdb-order-processor
           image: <docker-id>/cosmosdb-order-processor:latest
@@ -26,8 +26,8 @@ spec:
               value: <connection-string-of-monitored-container>
             - name: CosmosDbConfig__LeaseConnection
               value: <connection-string-of-lease-container>
-            - name: CosmosDbConfig__MSIClientId
-              value: "<>"
+            - name: CosmosDbConfig__MsiClientId
+              value: "<client-id>"
             - name: CosmosDbConfig__DatabaseId
               value: "StoreDatabase"
             - name: CosmosDbConfig__ContainerId

--- a/src/Scaler.Demo/OrderProcessor/deploy.yaml
+++ b/src/Scaler.Demo/OrderProcessor/deploy.yaml
@@ -19,13 +19,13 @@ spec:
       serviceAccountName: sa
       containers:
         - name: cosmosdb-order-processor
-          image: <>
+          image: <docker-id>/cosmosdb-order-processor:latest
           imagePullPolicy: Always
           env:
             - name: CosmosDbConfig__Connection
-              value: "<>"
+              value: <connection-string-of-monitored-container>
             - name: CosmosDbConfig__LeaseConnection
-              value: "<>"
+              value: <connection-string-of-lease-container>
             - name: CosmosDbConfig__MSIClientId
               value: "<>"
             - name: CosmosDbConfig__DatabaseId

--- a/src/Scaler.Demo/OrderProcessor/sa.yaml
+++ b/src/Scaler.Demo/OrderProcessor/sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa  
+  annotations:
+    azure.workload.identity/client-id: <>
+    azure.workload.identity/tenant-id: <>

--- a/src/Scaler.Demo/OrderProcessor/sa.yaml
+++ b/src/Scaler.Demo/OrderProcessor/sa.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: sa  
+  name: <service-account-name>  
   annotations:
-    azure.workload.identity/client-id: <>
-    azure.workload.identity/tenant-id: <>
+    azure.workload.identity/client-id: <client-id>
+    azure.workload.identity/tenant-id: <tenant-id>

--- a/src/Scaler.Demo/README.md
+++ b/src/Scaler.Demo/README.md
@@ -100,16 +100,23 @@ We will later deploy the order-processor application to Kubernetes cluster and u
 
 1. If using MI
 
- ```text
     a. Enable workload identity  
-    # az aks update -n <clusterName> -g <resourceGroupName> --enable-oidc-issuer --enable-workload-identity 
-    c. Create User Assigned Idenitty
-    # az identity create --name <identityName> --resource-group <resourceGroupName> --location <locationName> 
-    d. Grant MI access to the cluster: [Data Plane Role](https://aka.ms/dp-role-access), [Control Plane Role](https://aka.ms/cp-role-access)
-    e. [Createe Service Accoubt yaml](https://aka.ms/sa-aks-label)
-    f. Create federated identity credential 
-    # az identity federated-credential create --name <credentialName> --resource-group <resourceGroupName> --identity-name <identityName> --issuer <oidcIssuerUrl> --subject system:serviceaccount:<namespace>:<serviceaccountname>
- ```
+    ```text
+        # az aks update -n <cluster-name> -g <resource-group-name> --enable-oidc-issuer --enable-workload-identity 
+    ```
+    b. Create User Assigned Idenitty
+    ```text
+        # az identity create --name <identity-name> --resource-group <resource-group-name> --location <location-name> 
+    ```
+    c. Grant MI access to the cluster: [Data Plane Role](https://aka.ms/dp-role-access), [Control Plane Role](https://aka.ms/cp-role-access)
+
+    d. [Create Service Account yaml](https://aka.ms/sa-aks-label)
+
+    e. Create federated identity credential 
+    ```text
+        # az identity federated-credential create --name <credential-name> --resource-group <resource-group-name> --identity-name <identity-name> --issuer <oidc-issuer-url> --subject system:serviceaccount:<namespace>:<serviceaccountname>
+    ```
+
 
 1. Open command prompt or shell and change to the root directory of the cloned repo.
 

--- a/src/Scaler.Demo/Shared/CosmosDbConfig.cs
+++ b/src/Scaler.Demo/Shared/CosmosDbConfig.cs
@@ -13,6 +13,11 @@ namespace Keda.CosmosDb.Scaler.Demo.Shared
         public string LeaseContainerId { get; set; }
         public string ProcessorName { get; set; }
 
+        public string MSIClientID { get; set; }
+
+        public int OrderCount { get; set; }
+
+        public bool IsSingleArticle { get; set; }
         public static CosmosDbConfig Create(IConfiguration configuration)
         {
             return configuration.GetSection(nameof(CosmosDbConfig)).Get<CosmosDbConfig>();

--- a/src/Scaler.Demo/Shared/CosmosDbConfig.cs
+++ b/src/Scaler.Demo/Shared/CosmosDbConfig.cs
@@ -18,6 +18,8 @@ namespace Keda.CosmosDb.Scaler.Demo.Shared
         public int OrderCount { get; set; }
 
         public bool IsSingleArticle { get; set; }
+
+        public string Action { get; set; }
         public static CosmosDbConfig Create(IConfiguration configuration)
         {
             return configuration.GetSection(nameof(CosmosDbConfig)).Get<CosmosDbConfig>();

--- a/src/Scaler.Demo/Shared/CosmosDbConfig.cs
+++ b/src/Scaler.Demo/Shared/CosmosDbConfig.cs
@@ -12,13 +12,9 @@ namespace Keda.CosmosDb.Scaler.Demo.Shared
         public string LeaseDatabaseId { get; set; }
         public string LeaseContainerId { get; set; }
         public string ProcessorName { get; set; }
-
-        public string MSIClientID { get; set; }
-
+        public string MsiClientId { get; set; }
         public int OrderCount { get; set; }
-
         public bool IsSingleArticle { get; set; }
-
         public string Action { get; set; }
         public static CosmosDbConfig Create(IConfiguration configuration)
         {

--- a/src/Scaler.Demo/Shared/DemoHelper.cs
+++ b/src/Scaler.Demo/Shared/DemoHelper.cs
@@ -1,0 +1,54 @@
+﻿using Azure.Core;
+using Azure.Identity;
+using Microsoft.Azure.Cosmos;
+
+namespace Keda.CosmosDb.Scaler.Demo.Shared
+{
+    public static class DemoHelper
+    {
+
+        public static CosmosClient CreateCosmosClient(string endpointOrConnection, bool useCredentials, string clientId, string applicationName)
+        {
+            if (useCredentials)
+            {
+                var credential = GetChainedCredential(clientId);
+                return new CosmosClient(
+                    endpointOrConnection,
+                    credential,
+                    new CosmosClientOptions
+                    {
+                        ConnectionMode = ConnectionMode.Gateway,
+                        ApplicationName = applicationName,
+                        LimitToEndpoint = true
+                    });
+            }
+            else
+            {
+                return new CosmosClient(
+                    endpointOrConnection,
+                    new CosmosClientOptions
+                    {
+                        ConnectionMode = ConnectionMode.Gateway,
+                        ApplicationName = applicationName
+                    });
+            }
+        }
+
+        public static TokenCredential GetChainedCredential(string clientId)
+        {
+            var options = new DefaultAzureCredentialOptions
+            {
+                ManagedIdentityClientId = clientId,
+                ExcludeInteractiveBrowserCredential = true
+            };
+
+            var workloadIdentityCredentials = new WorkloadIdentityCredential(new WorkloadIdentityCredentialOptions { ClientId = clientId });
+            var azCliCredentials = new AzureCliCredential();
+
+            return new ChainedTokenCredential(
+                new DefaultAzureCredential(options),
+                workloadIdentityCredentials,
+                azCliCredentials);
+        }
+    }
+}

--- a/src/Scaler.Demo/Shared/DemoHelper.cs
+++ b/src/Scaler.Demo/Shared/DemoHelper.cs
@@ -6,15 +6,13 @@ namespace Keda.CosmosDb.Scaler.Demo.Shared
 {
     public static class DemoHelper
     {
-
         public static CosmosClient CreateCosmosClient(string endpointOrConnection, bool useCredentials, string clientId, string applicationName)
         {
             if (useCredentials)
             {
-                var credential = GetChainedCredential(clientId);
                 return new CosmosClient(
                     endpointOrConnection,
-                    credential,
+                    GetChainedCredential(clientId),
                     new CosmosClientOptions
                     {
                         ConnectionMode = ConnectionMode.Gateway,
@@ -36,19 +34,19 @@ namespace Keda.CosmosDb.Scaler.Demo.Shared
 
         public static TokenCredential GetChainedCredential(string clientId)
         {
-            var options = new DefaultAzureCredentialOptions
-            {
-                ManagedIdentityClientId = clientId,
-                ExcludeInteractiveBrowserCredential = true
-            };
-
-            var workloadIdentityCredentials = new WorkloadIdentityCredential(new WorkloadIdentityCredentialOptions { ClientId = clientId });
-            var azCliCredentials = new AzureCliCredential();
-
             return new ChainedTokenCredential(
-                new DefaultAzureCredential(options),
-                workloadIdentityCredentials,
-                azCliCredentials);
+                new DefaultAzureCredential(
+                    new DefaultAzureCredentialOptions
+                        {
+                            ManagedIdentityClientId = clientId,
+                            ExcludeInteractiveBrowserCredential = true
+                        }),
+                new WorkloadIdentityCredential(
+                    new WorkloadIdentityCredentialOptions 
+                    { 
+                        ClientId = clientId 
+                    }),
+                new AzureCliCredential());
         }
     }
 }

--- a/src/Scaler.Demo/Shared/Keda.CosmosDb.Scaler.Demo.Shared.csproj
+++ b/src/Scaler.Demo/Shared/Keda.CosmosDb.Scaler.Demo.Shared.csproj
@@ -8,5 +8,6 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
     <PackageReference Include="NewtonSoft.Json" Version="13.0.3" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
   </ItemGroup>
 </Project>

--- a/src/Scaler.Tests/CosmosDbScalerServiceTests.cs
+++ b/src/Scaler.Tests/CosmosDbScalerServiceTests.cs
@@ -254,7 +254,8 @@ namespace Keda.CosmosDb.Scaler.Tests
             {
                 scalerMetadata["endpoint"] = "https://example1.com:443/";
                 scalerMetadata["leaseEndpoint"] = "https://example2.com:443/";
-            } else
+            } 
+            else
             {
                 scalerMetadata["connectionFromEnv"] = "AccountEndpoint=https://example1.com:443/;AccountKey=ZHVtbXkx";
                 scalerMetadata["leaseConnectionFromEnv"] = "AccountEndpoint=https://example2.com:443/;AccountKey=ZHVtbXky";

--- a/src/Scaler/Keda.CosmosDb.Scaler.csproj
+++ b/src/Scaler/Keda.CosmosDb.Scaler.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+	<PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.67.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />

--- a/src/Scaler/Services/CosmosDbFactory.cs
+++ b/src/Scaler/Services/CosmosDbFactory.cs
@@ -23,11 +23,23 @@ namespace Keda.CosmosDb.Scaler
             if (useCredentials)
             {
                 var credential = GetChainedCredential(clientId);
-                return new CosmosClient(endpointOrConnection, credential, new CosmosClientOptions { ConnectionMode = ConnectionMode.Gateway, ApplicationName = _applicationName });
+                return new CosmosClient(
+                    endpointOrConnection, 
+                    credential, 
+                    new CosmosClientOptions { 
+                        ConnectionMode = ConnectionMode.Gateway,
+                        ApplicationName = _applicationName, 
+                        LimitToEndpoint = true
+                    });
             }
             else
             {
-                return new CosmosClient(endpointOrConnection, new CosmosClientOptions { ConnectionMode = ConnectionMode.Gateway, ApplicationName = _applicationName });
+                return new CosmosClient(
+                    endpointOrConnection, 
+                    new CosmosClientOptions { 
+                        ConnectionMode = ConnectionMode.Gateway,
+                        ApplicationName = _applicationName 
+                    });
             }
         }
 
@@ -39,11 +51,18 @@ namespace Keda.CosmosDb.Scaler
         /// <returns></returns>
         private TokenCredential GetChainedCredential(string clientId)
         {
-            var managedIdentityCredentials = new ManagedIdentityCredential(clientId: clientId);
+            var options = new DefaultAzureCredentialOptions {
+                    ManagedIdentityClientId = clientId,
+                    ExcludeInteractiveBrowserCredential = true 
+            };
+
             var workloadIdentityCredentials = new WorkloadIdentityCredential(new WorkloadIdentityCredentialOptions { ClientId = clientId });
             var azCliCredentials = new AzureCliCredential();
 
-            return new ChainedTokenCredential(managedIdentityCredentials, workloadIdentityCredentials, azCliCredentials);
+            return new ChainedTokenCredential(
+                new DefaultAzureCredential(options), 
+                workloadIdentityCredentials, 
+                azCliCredentials);
         }
     }
 }

--- a/src/Scaler/Services/CosmosDbFactory.cs
+++ b/src/Scaler/Services/CosmosDbFactory.cs
@@ -1,22 +1,49 @@
 using System.Collections.Concurrent;
+
+using Azure.Core;
+using Azure.Identity;
 using Microsoft.Azure.Cosmos;
 
 namespace Keda.CosmosDb.Scaler
 {
     internal sealed class CosmosDbFactory
     {
+        private const string _applicationName = "keda-external-azure-cosmos-db";
         // As per https://docs.microsoft.com/dotnet/api/microsoft.azure.cosmos.cosmosclient, it is recommended to
         // maintain a single instance of CosmosClient per lifetime of the application.
-        private readonly ConcurrentDictionary<string, CosmosClient> _cosmosClientCache = new();
+        private readonly ConcurrentDictionary<(string, string), CosmosClient> _cosmosClientCache = new();
 
-        public CosmosClient GetCosmosClient(string connection)
+        public CosmosClient GetCosmosClient(string endpointOrConnection, bool useCredentials, string clientId)
         {
-            return _cosmosClientCache.GetOrAdd(connection, CreateCosmosClient);
+            return _cosmosClientCache.GetOrAdd((endpointOrConnection, clientId), CreateCosmosClient(endpointOrConnection, useCredentials, clientId));
         }
 
-        private CosmosClient CreateCosmosClient(string connection)
+        private CosmosClient CreateCosmosClient(string endpointOrConnection, bool useCredentials, string clientId)
         {
-            return new CosmosClient(connection, new CosmosClientOptions { ConnectionMode = ConnectionMode.Gateway });
+            if (useCredentials)
+            {
+                var credential = GetChainedCredential(clientId);
+                return new CosmosClient(endpointOrConnection, credential, new CosmosClientOptions { ConnectionMode = ConnectionMode.Gateway, ApplicationName = _applicationName });
+            }
+            else
+            {
+                return new CosmosClient(endpointOrConnection, new CosmosClientOptions { ConnectionMode = ConnectionMode.Gateway, ApplicationName = _applicationName });
+            }
+        }
+
+        /// <summary>
+        /// Returns a chained token credential to be used for authentication. Supports managed identity, workload identity credentials
+        /// on Azure, while az CLI credentials can be used for local testing.
+        /// </summary>
+        /// <param name="clientId">ClientId of the identity to be used. System identity is used if this is null. </param>
+        /// <returns></returns>
+        private TokenCredential GetChainedCredential(string clientId)
+        {
+            var managedIdentityCredentials = new ManagedIdentityCredential(clientId: clientId);
+            var workloadIdentityCredentials = new WorkloadIdentityCredential(new WorkloadIdentityCredentialOptions { ClientId = clientId });
+            var azCliCredentials = new AzureCliCredential();
+
+            return new ChainedTokenCredential(managedIdentityCredentials, workloadIdentityCredentials, azCliCredentials);
         }
     }
 }

--- a/src/Scaler/Services/CosmosDbFactory.cs
+++ b/src/Scaler/Services/CosmosDbFactory.cs
@@ -21,10 +21,9 @@ namespace Keda.CosmosDb.Scaler
         {
             if (useCredentials)
             {
-                var credential = GetChainedCredential(clientId);
                 return new CosmosClient(
                     endpointOrConnection, 
-                    credential, 
+                    GetChainedCredential(clientId), 
                     new CosmosClientOptions { 
                         ConnectionMode = ConnectionMode.Gateway,
                         ApplicationName = _applicationName, 
@@ -48,20 +47,21 @@ namespace Keda.CosmosDb.Scaler
         /// </summary>
         /// <param name="clientId">ClientId of the identity to be used. System identity is used if this is null. </param>
         /// <returns></returns>
-        private TokenCredential GetChainedCredential(string clientId)
+        public static TokenCredential GetChainedCredential(string clientId)
         {
-            var options = new DefaultAzureCredentialOptions {
-                    ManagedIdentityClientId = clientId,
-                    ExcludeInteractiveBrowserCredential = true 
-            };
-
-            var workloadIdentityCredentials = new WorkloadIdentityCredential(new WorkloadIdentityCredentialOptions { ClientId = clientId });
-            var azCliCredentials = new AzureCliCredential();
-
             return new ChainedTokenCredential(
-                new DefaultAzureCredential(options), 
-                workloadIdentityCredentials, 
-                azCliCredentials);
+                new DefaultAzureCredential(
+                    new DefaultAzureCredentialOptions
+                        {
+                            ManagedIdentityClientId = clientId,
+                            ExcludeInteractiveBrowserCredential = true
+                        }),
+                new WorkloadIdentityCredential(
+                    new WorkloadIdentityCredentialOptions 
+                    { 
+                        ClientId = clientId 
+                    }),
+                new AzureCliCredential());
         }
     }
 }

--- a/src/Scaler/Services/CosmosDbFactory.cs
+++ b/src/Scaler/Services/CosmosDbFactory.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.Azure.Cosmos;

--- a/src/Scaler/Services/CosmosDbMetricProvider.cs
+++ b/src/Scaler/Services/CosmosDbMetricProvider.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
 
@@ -19,22 +20,32 @@ namespace Keda.CosmosDb.Scaler
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
+        private CosmosClient GetCosmosClientFromMetadata(ScalerMetadata metadata)
+        {
+            // Prioritize credential based connections
+            if (!string.IsNullOrWhiteSpace(metadata.Endpoint))
+            {
+                return _factory.GetCosmosClient(metadata.Endpoint, useCredentials: true, clientId: metadata.ClientId);
+            }
+            else
+            {
+                return _factory.GetCosmosClient(metadata.Connection , useCredentials: false, clientId: null);
+            }
+        }
+
         public async Task<long> GetPartitionCountAsync(ScalerMetadata scalerMetadata)
         {
             try
             {
-                Container leaseContainer = _factory
-                    .GetCosmosClient(scalerMetadata.LeaseConnection)
+                Container leaseContainer = GetCosmosClientFromMetadata(scalerMetadata)
                     .GetContainer(scalerMetadata.LeaseDatabaseId, scalerMetadata.LeaseContainerId);
 
-                ChangeFeedEstimator estimator = _factory
-                    .GetCosmosClient(scalerMetadata.Connection)
+                ChangeFeedEstimator estimator = GetCosmosClientFromMetadata(scalerMetadata)
                     .GetContainer(scalerMetadata.DatabaseId, scalerMetadata.ContainerId)
                     .GetChangeFeedEstimator(scalerMetadata.ProcessorName, leaseContainer);
 
                 // It does not help by creating more change-feed processing instances than the number of partitions.
                 int partitionCount = 0;
-
                 using (FeedIterator<ChangeFeedProcessorState> iterator = estimator.GetCurrentStateIterator())
                 {
                     while (iterator.HasMoreResults)

--- a/src/Scaler/Services/CosmosDbMetricProvider.cs
+++ b/src/Scaler/Services/CosmosDbMetricProvider.cs
@@ -22,7 +22,7 @@ namespace Keda.CosmosDb.Scaler
 
         private CosmosClient GetCosmosClientFromMetadata(ScalerMetadata metadata)
         {
-            // Prioritize credential based connections
+            // Prioritize credential-based connections
             if (!string.IsNullOrWhiteSpace(metadata.Endpoint))
             {
                 return _factory.GetCosmosClient(metadata.Endpoint, useCredentials: true, clientId: metadata.ClientId);

--- a/src/Scaler/Services/ScalerMetadata.cs
+++ b/src/Scaler/Services/ScalerMetadata.cs
@@ -14,61 +14,59 @@ namespace Keda.CosmosDb.Scaler
         /// <summary>
         /// ID of Cosmos DB database containing monitored container.
         /// </summary>
-        [JsonProperty(Required = Required.Always)]
         [JsonRequired]
         public string DatabaseId { get; set; }
 
         /// <summary>
         /// ID of monitored container.
         /// </summary>
-        [JsonProperty(Required = Required.Always)]
         public string ContainerId { get; set; }
 
         /// <summary>
         /// ID of Cosmos DB database containing lease container.
         /// </summary>
-        [JsonProperty(Required = Required.Always)]
         public string LeaseDatabaseId { get; set; }
 
         /// <summary>
         /// ID of lease container.
         /// </summary>
-        [JsonProperty(Required = Required.Always)]
         public string LeaseContainerId { get; set; }
 
         // Connection String properties
         /// <summary>
         /// Environment variable for the connection string of Cosmos DB account with monitored container.
         /// </summary>
-        [JsonProperty("ConnectionFromEnv")]
+        [JsonProperty("ConnectionFromEnv", Required = Required.Default)]
         public string Connection { get; set; }
 
         /// <summary>
         /// Environment variable for the connection string of Cosmos DB account with lease container.
         /// </summary>
-        [JsonProperty("LeaseConnectionFromEnv")]
+        [JsonProperty("LeaseConnectionFromEnv", Required = Required.Default)]
         public string LeaseConnection { get; set; }
 
         // Managed Identity properties
         /// <summary>
         /// Account endpoint of the CosmosDB account containing the monitored container.
         /// </summary>
+        [JsonProperty(Required = Required.Default)]
         public string Endpoint { get; set; }
 
         /// <summary>
         /// Account endpoint of the CosmosDB account containing the lease container.
         /// </summary>
+        [JsonProperty(Required = Required.Default)]
         public string LeaseEndpoint { get; set; }
 
         /// <summary>
         /// ClientId of the identity to be used. System assigned identity is used, if this is null.
         /// </summary>
+        [JsonProperty(Required = Required.Default)]
         public string ClientId { get; set; }
 
         /// <summary>
         /// Name of change-feed processor used by listener application.
         /// </summary>
-        [JsonProperty(Required = Required.Always)]
         public string ProcessorName { get; set; }
 
         [JsonProperty(Required = Required.DisallowNull)]

--- a/src/Scaler/Services/ScalerMetadata.cs
+++ b/src/Scaler/Services/ScalerMetadata.cs
@@ -14,7 +14,6 @@ namespace Keda.CosmosDb.Scaler
         /// <summary>
         /// ID of Cosmos DB database containing monitored container.
         /// </summary>
-        [JsonRequired]
         public string DatabaseId { get; set; }
 
         /// <summary>
@@ -91,9 +90,9 @@ namespace Keda.CosmosDb.Scaler
         {
             get
             {
-                if (!string.IsNullOrWhiteSpace(Endpoint))
+                if (!string.IsNullOrWhiteSpace(LeaseEndpoint))
                 {
-                    return new Uri(this.LeaseEndpoint).Host;
+                    return new Uri(LeaseEndpoint).Host;
                 }
                 else
                 {

--- a/src/Scaler/deploy.yaml
+++ b/src/Scaler/deploy.yaml
@@ -10,15 +10,16 @@ spec:
   selector:
     matchLabels:
       app: cosmosdb-scaler
-      # Optional: Use Workload Identity for authentication. Refer https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html for more details.
-      azure.workload.identity/use: true 
+      azure.workload.identity/use: "true"
   template:
     metadata:
       labels:
         app: cosmosdb-scaler
+        azure.workload.identity/use: "true"
     spec:
+      serviceAccountName: sa
       containers:
-        - image: <docker-id>/cosmosdb-scaler:latest
+        - image: vishal7991/cosmosdb-scaler:dev
           imagePullPolicy: Always
           name: cosmosdb-scaler
           ports:

--- a/src/Scaler/deploy.yaml
+++ b/src/Scaler/deploy.yaml
@@ -10,6 +10,8 @@ spec:
   selector:
     matchLabels:
       app: cosmosdb-scaler
+      # Optional: Use Workload Identity for authentication. Refer https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html for more details.
+      azure.workload.identity/use: true 
   template:
     metadata:
       labels:

--- a/src/Scaler/deploy.yaml
+++ b/src/Scaler/deploy.yaml
@@ -17,7 +17,7 @@ spec:
         app: cosmosdb-scaler
         azure.workload.identity/use: "true"
     spec:
-      serviceAccountName: sa
+      serviceAccountName: <service-account-name>
       containers:
         - image: <docker-id>/cosmosdb-scaler:latest
           imagePullPolicy: Always

--- a/src/Scaler/deploy.yaml
+++ b/src/Scaler/deploy.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     matchLabels:
       app: cosmosdb-scaler
-      azure.workload.identity/use: "true"
+      azure.workload.identity/use: "true" # Optional: Use Workload Identity for authentication. Refer https://azure.github.io/azure-workload-identity/docs/topics/service-account-labels-and-annotations.html for more details.
   template:
     metadata:
       labels:

--- a/src/Scaler/deploy.yaml
+++ b/src/Scaler/deploy.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: sa
       containers:
-        - image: vishal7991/cosmosdb-scaler:dev
+        - image: <docker-id>/cosmosdb-scaler:latest
           imagePullPolicy: Always
           name: cosmosdb-scaler
           ports:


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

1. This PR introduces Managed Identity (MI) support for the Azure Cosmos DB external scaler and updates the Demo project to use MI-based access for autoscaling
2. Included detailed steps for configuring and deploying the Demo project with MI-based access.

Manual testing and validation:
1. Used the Demo app in the repo to generate data in cosmos DB, used MSI to access cosmos DB. 
2. Used the Demo app in the repo to process the data generated in the first step, used MSI to access the cosmosDB. 
3. Created the scale object having the clientId of MSI as properties, validated the pods count increased to 2 from 0 and back to 0 after processing all the data. 

The manual testing was performed on AKS cluster, details to setup the cluster with MSI is added in the Readme file of the demo app. 

Original PR: https://github.com/kedacore/external-scaler-azure-cosmos-db/pull/78
### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

Fixes #
